### PR TITLE
Bugfix: Fix crash inside closures

### DIFF
--- a/test/bug_enum_constructor_without_param_in_closure.hds
+++ b/test/bug_enum_constructor_without_param_in_closure.hds
@@ -1,0 +1,24 @@
+import submodule.printable_interface as P
+import submodule.constants as C
+
+def main(): Void {
+  val f = ||: Void {
+    val x = T.X
+    val p = Tr[usize].foo()
+    val x = P.Printable[Int].print(1)
+    val y = C.THREE
+  }
+}
+
+trait Tr[Self] {
+    def foo(): Bool
+}
+implementation Tr[usize] {
+    def foo(): Bool {
+        return true
+    }
+}
+
+enum T {
+  X
+}

--- a/test/submodule/printable_interface.hds
+++ b/test/submodule/printable_interface.hds
@@ -9,3 +9,7 @@ implementation Printable[Int] {
 trait Printable[Self] {
     def print(self: Self): Void;
 }
+
+def print[T](self: T): Void where Printable[Self] {
+  Printable[T].print(self);
+}


### PR DESCRIPTION
Referring to property expressions whose lhs is not
a proper expression, (e.g. SomeModule.foo, SomeTrait[T].method())
doesn't crash the compiler anymore.