### PR TITLE
Allow not operator in where clauses

### DIFF
--- a/hadesboot/src/main/kotlin/hadesc/analysis/Analyzer.kt
+++ b/hadesboot/src/main/kotlin/hadesc/analysis/Analyzer.kt
@@ -1276,7 +1276,7 @@ class Analyzer(
 
     fun isTraitRequirementSatisfied(callNode: HasLocation, requiredInstance: TraitRequirement): Boolean {
         val traitResolver = makeTraitResolver(callNode)
-        return traitResolver.isTraitImplemented(requiredInstance.traitRef, requiredInstance.arguments)
+        return traitResolver.isSatisfied(requiredInstance)
     }
 
     fun isCopyAllowed(callNode: HasLocation, type: Type): Boolean {

--- a/hadesboot/src/main/kotlin/hadesc/analysis/Analyzer.kt
+++ b/hadesboot/src/main/kotlin/hadesc/analysis/Analyzer.kt
@@ -457,7 +457,7 @@ class Analyzer(
         if (declaration !is Declaration.TraitDef) {
             null
         } else {
-            TraitRequirement(ctx.resolver.qualifiedName(declaration.name), args ?: listOf())
+            TraitRequirement(ctx.resolver.qualifiedName(declaration.name), args ?: listOf(), negated = requirement.negated)
         }
 
     }
@@ -1285,7 +1285,8 @@ class Analyzer(
             callNode,
             TraitRequirement(
                 ctx.qn("hadesx", "NoCopy", "NoCopy"),
-                listOf(reducedType)
+                listOf(reducedType),
+                negated = false
             )
         )
         return !isNoCopy
@@ -1949,9 +1950,11 @@ class Analyzer(
         is TypeAnnotation.Var -> {
             val traitDef = ctx.resolver.resolveTraitDef(type.name)
             if (traitDef != null) {
+                // TODO: Investigate if we're hitting this code path
                 TraitRequirement(
                     ctx.resolver.qualifiedName(traitDef.name),
-                    emptyList()
+                    emptyList(),
+                    negated = false
                 )
             } else
                 null
@@ -1961,7 +1964,8 @@ class Analyzer(
                 if (it is Declaration.TraitDef) {
                     TraitRequirement(
                         ctx.resolver.qualifiedName(it.name),
-                        arguments = emptyList()
+                        arguments = emptyList(),
+                        negated = false
                     )
                 } else {
                     null

--- a/hadesboot/src/main/kotlin/hadesc/analysis/TraitResolver.kt
+++ b/hadesboot/src/main/kotlin/hadesc/analysis/TraitResolver.kt
@@ -66,7 +66,8 @@ class TraitResolver<Def>(private val env: Env<Def>, private val typeAnalyzer: Ty
     }
 
     private fun TraitRequirement.isSatisfied(substitution: Substitution): Boolean {
-        return isTraitImplemented(traitRef, arguments.map { it.applySubstitution(substitution) })
+        val isImplemented = isTraitImplemented(traitRef, arguments.map { it.applySubstitution(substitution) })
+        return if (negated) !isImplemented else isImplemented
     }
 
     private infix fun Type.isAssignableTo(destination: Type): Boolean {

--- a/hadesboot/src/main/kotlin/hadesc/analysis/TraitResolver.kt
+++ b/hadesboot/src/main/kotlin/hadesc/analysis/TraitResolver.kt
@@ -23,6 +23,10 @@ class TraitResolver<Def>(private val env: Env<Def>, private val typeAnalyzer: Ty
     fun isTraitImplemented(traitRef: QualifiedName, arguments: List<Type>): Boolean {
         return getImplementationClauseAndSubstitution(traitRef, arguments) != null
     }
+    fun isSatisfied(requirement: TraitRequirement): Boolean {
+        val isImplemented = isTraitImplemented(requirement.traitRef, requirement.arguments)
+        return if (requirement.negated) !isImplemented else isImplemented
+    }
 
 
     private fun getImplementationSubstitution(traitRef: QualifiedName, arguments: List<Type>, clause: TraitClause<Def>): Substitution? {
@@ -59,6 +63,9 @@ class TraitResolver<Def>(private val env: Env<Def>, private val typeAnalyzer: Ty
                     if (!(clauseArg isAssignableTo arg)) {
                         return null
                     }
+                }
+                if (clause.requirement.negated) {
+                    return null
                 }
                 emptySubstitution()
             }

--- a/hadesboot/src/main/kotlin/hadesc/analysis/TraitResolver.kt
+++ b/hadesboot/src/main/kotlin/hadesc/analysis/TraitResolver.kt
@@ -96,19 +96,22 @@ sealed class TraitClause<Def> {
 
 data class TraitRequirement(
         val traitRef: QualifiedName,
-        val arguments: List<Type>
+        val arguments: List<Type>,
+        val negated: Boolean
 ) {
     override fun toString(): String {
         if (arguments.isEmpty()) {
             return traitRef.mangle()
         }
-        return "${traitRef.mangle()}[${arguments.joinToString(", ") { it.prettyPrint() } }]"
+        val notPrefix = if (negated) "not " else ""
+        return "$notPrefix${traitRef.mangle()}[${arguments.joinToString(", ") { it.prettyPrint() } }]"
     }
 
     fun applySubstitution(substitution: Substitution): TraitRequirement {
         return TraitRequirement(
                 traitRef,
-                arguments.map { it.applySubstitution(substitution) }
+                arguments.map { it.applySubstitution(substitution) },
+                negated = negated
         )
     }
 

--- a/hadesboot/src/main/kotlin/hadesc/ast/TraitRequirementAnnotation.kt
+++ b/hadesboot/src/main/kotlin/hadesc/ast/TraitRequirementAnnotation.kt
@@ -5,7 +5,8 @@ import hadesc.location.SourceLocation
 
 data class TraitRequirementAnnotation(
         val path: QualifiedPath,
-        val typeArgs: List<TypeAnnotation>?
+        val typeArgs: List<TypeAnnotation>?,
+        val negated: Boolean
 ): HasLocation {
         override val location get() = SourceLocation.between(path, typeArgs?.lastOrNull() ?: path)
 }

--- a/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
+++ b/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
@@ -970,7 +970,8 @@ class Checker(val ctx: Context) {
             if (propertyBinding is PropertyBinding.TraitFunctionRef) {
                 val requirement = TraitRequirement(
                     propertyBinding.traitName,
-                    propertyBinding.args
+                    propertyBinding.args,
+                    negated = false,
                 )
                 val traitDef = ctx.resolver.resolveDeclaration(requirement.traitRef)
                 require(traitDef is Declaration.TraitDef)

--- a/hadesboot/src/main/kotlin/hadesc/hir/TypeTransformer.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/TypeTransformer.kt
@@ -68,7 +68,7 @@ interface TypeTransformer {
     )
 
     fun lowerTraitRequirement(requirement: TraitRequirement): TraitRequirement {
-        return TraitRequirement(requirement.traitRef, requirement.arguments.map { lowerType(it) })
+        return TraitRequirement(requirement.traitRef, requirement.arguments.map { lowerType(it) }, negated = requirement.negated)
     }
 
     fun lowerSizeType(type: Type): Type = type

--- a/hadesboot/src/main/kotlin/hadesc/hir/passes/Monomorphization.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/passes/Monomorphization.kt
@@ -258,7 +258,7 @@ class Monomorphization(
                 params = impl.typeParams?.map { Type.Param(it.toBinder()) } ?: emptyList(),
                 traitRef = impl.traitName,
                 arguments = impl.traitArgs,
-                requirements = impl.traitRequirements.map { TraitRequirement(it.traitRef, it.arguments) }
+                requirements = impl.traitRequirements.map { TraitRequirement(it.traitRef, it.arguments, it.negated) }
 
             )
         }

--- a/hadesboot/src/main/kotlin/hadesc/hir/passes/Monomorphization.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/passes/Monomorphization.kt
@@ -317,9 +317,11 @@ class Monomorphization(
             )
 
             if (!candidate.traitRequirements.all { requirement ->
-                    traitResolver.isTraitImplemented(
-                        requirement.traitRef,
-                        requirement.arguments.map { it.applySubstitution(substitution) }) })
+                    traitResolver.isSatisfied(
+                        requirement.copy(
+                            arguments = requirement.arguments.map { it.applySubstitution(substitution) })
+                        )
+            })
                 continue
             val subst = (substitutionMap.mapValues {
                 requireNotNull(typeAnalyzer.getInstantiatedType(it.value)) })

--- a/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGen.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGen.kt
@@ -203,7 +203,8 @@ class HIRGen(private val ctx: Context): ASTContext by ctx, HIRGenModuleContext, 
         require(traitDef is Declaration.TraitDef)
         return TraitRequirement(
             ctx.resolver.qualifiedName(traitDef.name),
-            requirement.typeArgs?.map { lowerTypeAnnotation(it) } ?: emptyList()
+            requirement.typeArgs?.map { lowerTypeAnnotation(it) } ?: emptyList(),
+            requirement.negated
         )
     }
 

--- a/hadesboot/src/main/kotlin/hadesc/parser/Parser.kt
+++ b/hadesboot/src/main/kotlin/hadesc/parser/Parser.kt
@@ -313,13 +313,18 @@ class Parser(
     }
 
     private fun parseTraitRef(): TraitRequirementAnnotation {
+        val negated =
+            if (currentToken.kind == TokenKind.NOT)
+                advance().let { true }
+            else
+                false
         val path = parseQualifiedPath()
         expect(tt.LSQB)
         val args = parseSeperatedList(tt.COMMA, tt.RSQB) {
             parseTypeAnnotation()
         }
         expect(tt.RSQB)
-        return TraitRequirementAnnotation(path, args, negated = false)
+        return TraitRequirementAnnotation(path, args, negated = negated)
     }
 
     private fun parseFunctionSignature(): FunctionSignature {

--- a/hadesboot/src/main/kotlin/hadesc/parser/Parser.kt
+++ b/hadesboot/src/main/kotlin/hadesc/parser/Parser.kt
@@ -319,7 +319,7 @@ class Parser(
             parseTypeAnnotation()
         }
         expect(tt.RSQB)
-        return TraitRequirementAnnotation(path, args)
+        return TraitRequirementAnnotation(path, args, negated = false)
     }
 
     private fun parseFunctionSignature(): FunctionSignature {

--- a/hadesboot/src/main/kotlin/hadesc/types/Type.kt
+++ b/hadesboot/src/main/kotlin/hadesc/types/Type.kt
@@ -102,7 +102,7 @@ sealed interface Type {
             is Function -> Function(
                 from = this.from.map { it.recurse() },
                 traitRequirements = this.traitRequirements?.map {
-                    TraitRequirement(it.traitRef, it.arguments.map { t -> t.recurse() })
+                    TraitRequirement(it.traitRef, it.arguments.map { t -> t.recurse() }, it.negated)
                 },
                 to = this.to.recurse()
             )

--- a/hadesboot/src/test/kotlin/hadesc/TraitResolverTest.kt
+++ b/hadesboot/src/test/kotlin/hadesc/TraitResolverTest.kt
@@ -64,7 +64,7 @@ class TraitResolverTest {
     }
 
     private fun requirement(traitRef: QualifiedName, vararg args: Type): TraitRequirement {
-        return TraitRequirement(traitRef, listOf(*args))
+        return TraitRequirement(traitRef, listOf(*args), negated = false)
     }
 
     private fun tycon(name: String): Type.Constructor {

--- a/test/specialization_using_not.hds
+++ b/test/specialization_using_not.hds
@@ -1,0 +1,29 @@
+struct Box[T] {}
+trait Foo[T] {
+    def foo(): Void
+}
+implementation Foo[Bool] {
+    def foo(): Void {}
+}
+
+implementation[T] Foo[Box[T]] where Foo[T] {
+    def foo(): Void {
+        puts(b"Contains Foo")
+    }
+}
+implementation[T] Foo[Box[T]] where not Foo[T] {
+    def foo(): Void {
+        puts(b"Does not contain Foo")
+    }
+}
+
+def foo[T](): Void where Foo[T] {
+    Foo[T].foo()
+}
+def main(): Void {
+    foo[Box[Bool]]()
+    foo[Box[usize]]()
+}
+
+
+extern def puts(*u8): Void = puts

--- a/test/specialization_using_not.stdout
+++ b/test/specialization_using_not.stdout
@@ -1,0 +1,2 @@
+Contains Foo
+Does not contain Foo

--- a/test/where_not.errors
+++ b/test/where_not.errors
@@ -1,0 +1,1 @@
+test/where_not.hds:4: TraitRequirementNotSatisfied

--- a/test/where_not.hds
+++ b/test/where_not.hds
@@ -1,0 +1,13 @@
+
+def main(): Void {
+    not_foo(b"123")
+    not_foo(true) // expected error because Bool is not Foo
+}
+trait Foo[T] {}
+
+implementation Foo[Bool] {}
+
+def not_foo[T](t: T): Void where not Foo[T] {
+    not_foo(t) // allowed because of the clause on this method
+}
+


### PR DESCRIPTION
This allows us to specialize trait implementations depending on whether a trait is implemented or not.

The motivating example was `Vec[T]` should implement `Drop` differently depending on whether `T` is drop or not. If it is, it has to call `Drop[T].drop` on it. Otherwise not.