### PR TITLE
Improve error messages

### DIFF
--- a/hadesboot/src/main/kotlin/hadesc/analysis/Analyzer.kt
+++ b/hadesboot/src/main/kotlin/hadesc/analysis/Analyzer.kt
@@ -404,6 +404,10 @@ class Analyzer(
         )
     }
 
+    fun reduceAssociatedType(type: Type, at: HasLocation): Type {
+        return type.reduceSelectTypes(at)
+    }
+
     private fun Type.reduceSelectTypes(at: HasLocation): Type {
         return object : TypeTransformer {
             override fun lowerSelectType(type: Type.Select): Type {

--- a/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
+++ b/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
@@ -509,7 +509,9 @@ class Checker(val ctx: Context) {
         checkExpression(expression)
         val exprType = ctx.analyzer.typeOfExpression(expression)
         if (!exprType.isAssignableTo(expression, type)) {
-            error(expression, Diagnostic.Kind.TypeNotAssignable(source = exprType, destination = type))
+            error(expression, Diagnostic.Kind.TypeNotAssignable(
+                source = ctx.analyzer.reduceGenericInstances(ctx.analyzer.reduceAssociatedType(exprType, expression)),
+                destination = type))
         }
     }
 

--- a/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
+++ b/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
@@ -218,6 +218,7 @@ class Checker(val ctx: Context) {
 
     private fun checkExtensionDef(declaration: Declaration.ExtensionDef) {
         checkTypeAnnotation(declaration.forType)
+        declaration.whereClause?.let { checkWhereClause(it) }
         for (decl in declaration.declarations) {
             if (decl !is Declaration.FunctionDef) {
                 error(decl.startLoc, Diagnostic.Kind.OnlyFunctionDefsAllowedInsideExtensionDefs)

--- a/test/bug_check_where_clause_in_extension.errors
+++ b/test/bug_check_where_clause_in_extension.errors
@@ -1,0 +1,2 @@
+test/bug_check_where_clause_in_extension.hds:2: NotATrait
+test/bug_check_where_clause_in_extension.hds:2: UnboundType

--- a/test/bug_check_where_clause_in_extension.hds
+++ b/test/bug_check_where_clause_in_extension.hds
@@ -1,0 +1,2 @@
+
+extension usizeExtns for usize where Foo[Bar] {}


### PR DESCRIPTION
1. Reduce associated type paths in error message. `Foo[Bar].Baz is not assignable to ...` error message now shows the fully reduced type of `Foo[Bar].Baz`
2. Type annotations in where clauses for extension defs are checked for errors. Previously, if there was an unbound variable in an extension where clause, it would not throw a type error