### PR TITLE
Add postfix operators for ref/deref pointer operations

### DIFF
--- a/test/postfix_ref_and_deref.hds
+++ b/test/postfix_ref_and_deref.hds
@@ -1,0 +1,19 @@
+
+def main(): Void {
+    val mut x = b"PASS"
+
+    val mut x_mut_ptr: *mut *u8 = x.&mut
+    val x_ptr: **u8 = x.&
+    puts(x_mut_ptr.*)
+    puts(x_ptr.*)
+
+    x.&.print()
+
+}
+extension StrExtensions for *u8 {
+    def print(*this): Void {
+        puts(this.*)
+    }
+}
+
+extern def puts(*u8): Void = puts

--- a/test/postfix_ref_and_deref.stdout
+++ b/test/postfix_ref_and_deref.stdout
@@ -1,0 +1,3 @@
+PASS
+PASS
+PASS


### PR DESCRIPTION
Now you can do
```
foo.&
foo.&mut
foo.&mut.method()
foo.&.method()
foo_ptr.*
// etc
```
This makes chaining these operations easier