### PR TITLE
Separate closure and fnptr types

### DIFF
--- a/hadesboot/src/main/kotlin/hadesc/analysis/TypeAnalyzer.kt
+++ b/hadesboot/src/main/kotlin/hadesc/analysis/TypeAnalyzer.kt
@@ -64,7 +64,14 @@ class TypeAnalyzer {
             destination is Type.Constructor && source is Type.Constructor -> {
                 destination.name == source.name
             }
-            destination is Type.Function && source is Type.Function -> {
+            destination is Type.FunctionPtr && source is Type.FunctionPtr -> {
+                destination.from.size == source.from.size
+                        && isTypeAssignableTo(source = source.to, destination = destination.to)
+                        && source.from.zip(destination.from).all { (sourceParam, destParam) ->
+                    isTypeAssignableTo(source = destParam, destination = sourceParam)
+                }
+            }
+            destination is Type.Closure && source is Type.Closure -> {
                 destination.from.size == source.from.size
                         && isTypeAssignableTo(source = source.to, destination = destination.to)
                         && source.from.zip(destination.from).all { (sourceParam, destParam) ->

--- a/hadesboot/src/main/kotlin/hadesc/ast/SyntaxVisitor.kt
+++ b/hadesboot/src/main/kotlin/hadesc/ast/SyntaxVisitor.kt
@@ -7,13 +7,19 @@ interface SyntaxVisitor {
     fun visitType(type: TypeAnnotation): Unit = when(type) {
         is TypeAnnotation.Application -> visitTypeApplicationType(type)
         is TypeAnnotation.Error -> visitErrorType(type)
-        is TypeAnnotation.Function -> visitFunctionType(type)
+        is TypeAnnotation.FunctionPtr -> visitFunctionType(type)
         is TypeAnnotation.MutPtr -> visitMutPtrType(type)
         is TypeAnnotation.Ptr -> visitPtrType(type)
         is TypeAnnotation.Qualified -> visitQualifiedType(type)
         is TypeAnnotation.Union -> visitUnionType(type)
         is TypeAnnotation.Var -> visitVarType(type)
         is TypeAnnotation.Select -> visitSelectType(type)
+        is TypeAnnotation.Closure -> visitClosureType(type)
+    }
+
+    fun visitClosureType(type: TypeAnnotation.Closure) {
+        type.from.forEach { visitType(it) }
+        visitType(type.to)
     }
 
     fun visitSelectType(type: TypeAnnotation.Select) {
@@ -39,7 +45,7 @@ interface SyntaxVisitor {
         visitType(type.to)
     }
 
-    fun visitFunctionType(type: TypeAnnotation.Function) {
+    fun visitFunctionType(type: TypeAnnotation.FunctionPtr) {
         type.from.forEach { visitType(it) }
         visitType(type.to)
     }

--- a/hadesboot/src/main/kotlin/hadesc/ast/typeannotation.kt
+++ b/hadesboot/src/main/kotlin/hadesc/ast/typeannotation.kt
@@ -31,11 +31,17 @@ sealed class TypeAnnotation : HasLocation {
         val qualifiedPath: QualifiedPath
     ) : TypeAnnotation()
 
-    data class Function(
+    data class FunctionPtr(
         override val location: SourceLocation,
         val from: List<TypeAnnotation>,
         val to: TypeAnnotation
     ) : TypeAnnotation()
+
+    data class Closure(
+        override val location: SourceLocation,
+        val from: List<TypeAnnotation>,
+        val to: TypeAnnotation,
+    ): TypeAnnotation()
 
     data class Union(
         override val location: SourceLocation,

--- a/hadesboot/src/main/kotlin/hadesc/codegen/HIRToLLVM.kt
+++ b/hadesboot/src/main/kotlin/hadesc/codegen/HIRToLLVM.kt
@@ -39,6 +39,7 @@ class HIRToLLVM(
 
     private val log = logger(HIRToLLVM::class.java)
     private val i32Ty = intType(32, llvmCtx)
+    @Suppress("unused")
     private val metadataTy = LLVM.LLVMMetadataTypeInContext(llvmCtx)
     private val errorStack = Stack<HIRStatement>()
 
@@ -821,6 +822,7 @@ class HIRToLLVM(
     }
 
     private val Type.sizeInBits get() = LLVM.LLVMSizeOfTypeInBits(dataLayout, lowerType(this))
+    @Suppress("unused")
     private val Type.sizeInBytes get() = LLVM.LLVMABISizeOfType(dataLayout, lowerType(this))
 
 

--- a/hadesboot/src/main/kotlin/hadesc/codegen/HIRToLLVM.kt
+++ b/hadesboot/src/main/kotlin/hadesc/codegen/HIRToLLVM.kt
@@ -177,12 +177,11 @@ class HIRToLLVM(
 
         val fileScope = getFileScope(definition.location.file)
         val defType = definition.type
-        check(defType is Type.Ptr && defType.to is Type.FunctionPtr)
-        val fnType = defType.to
+        check(defType is Type.FunctionPtr)
         val typeDI = LLVM.LLVMDIBuilderCreateSubroutineType(
             diBuilder, fileScope,
-            fnType.from.map { it.debugInfo }.asPointerPointer(),
-            fnType.from.size,
+            defType.from.map { it.debugInfo }.asPointerPointer(),
+            defType.from.size,
             LLVM.LLVMDIFlagZero
         )
 

--- a/hadesboot/src/main/kotlin/hadesc/codegen/HIRToLLVM.kt
+++ b/hadesboot/src/main/kotlin/hadesc/codegen/HIRToLLVM.kt
@@ -744,7 +744,9 @@ class HIRToLLVM(
 
     private fun lowerCallStatement(statement: HIRStatement.Call): Value {
         val calleeType = statement.callee.type
-        check(calleeType is Type.FunctionPtr)
+        check(calleeType is Type.FunctionPtr) {
+            statement.location
+        }
         val name = if (statement.resultType is Type.Void) null else ctx.makeUniqueName()
 
         val loweredCallee = lowerExpression(statement.callee)

--- a/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
+++ b/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
@@ -315,6 +315,7 @@ class Checker(val ctx: Context) {
     private fun checkClosureTypeAnnotation(annotation: TypeAnnotation.Closure) {
         annotation.from.forEach { checkTypeAnnotation(it) }
         checkTypeAnnotation(annotation.to)
+        checkReturnType(annotation, annotation.to.type)
     }
 
     private fun checkSelectTypeAnnotation(annotation: TypeAnnotation.Select) {

--- a/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
+++ b/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
@@ -100,11 +100,11 @@ class Checker(val ctx: Context) {
                 foundMethods.add(declaration.name.identifier.name)
                 val typeOfMethod = ctx.analyzer.typeOfBinder(declaration.name)
                 require(typeOfMethod is Type.FunctionPtr)
-                val actualType = typeOfMethod.to
                 val expectedType = expectedMethods[declaration.name.identifier.name]?.applySubstitution(associatedTypeSubstitution)
-                if (expectedType != null && !actualType.isAssignableTo(declaration, expectedType)) {
+                if (expectedType != null && !typeOfMethod.isAssignableTo(declaration, expectedType)) {
                     error(declaration.name, Diagnostic.Kind.TraitMethodTypeMismatch(
-                        expected = expectedType, found = actualType))
+                        expected = expectedType, found = typeOfMethod
+                    ))
                 }
             } else if (declaration is Declaration.TypeAlias) {
                 checkTypeAlias(declaration, skipDuplicateDeclarationCheck = true)

--- a/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
+++ b/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
@@ -99,7 +99,7 @@ class Checker(val ctx: Context) {
                 checkFunctionDef(declaration, skipDuplicateDeclarationCheck = false)
                 foundMethods.add(declaration.name.identifier.name)
                 val typeOfMethod = ctx.analyzer.typeOfBinder(declaration.name)
-                require(typeOfMethod is Type.Ptr)
+                require(typeOfMethod is Type.FunctionPtr)
                 val actualType = typeOfMethod.to
                 val expectedType = expectedMethods[declaration.name.identifier.name]?.applySubstitution(associatedTypeSubstitution)
                 if (expectedType != null && !actualType.isAssignableTo(declaration, expectedType)) {

--- a/hadesboot/src/main/kotlin/hadesc/hir/HIRBuilder.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/HIRBuilder.kt
@@ -319,21 +319,17 @@ fun HIRBuilder.emitCall(
 ): HIRStatement.Call {
     val calleeType = callee.type
     if (!skipVerification) {
-        check(calleeType is Type.Ptr) {
+        check(calleeType is Type.FunctionPtr) {
             "Expected ${calleeType.prettyPrint()} to be a function pointer"
         }
-        check(calleeType.to is Type.Function) {
-            "Expected ${calleeType.prettyPrint()} to be a function pointer"
-        }
-        val fnType = calleeType.to
-        check(fnType.from.size == args.size) {
-            "Wrong number of args to fn of type ${fnType.prettyPrint()}"
+        check(calleeType.from.size == args.size) {
+            "Wrong number of args to fn of type ${calleeType.prettyPrint()}"
         }
 
-        for ((expected, arg) in fnType.from.zip(args)) {
+        for ((expected, arg) in calleeType.from.zip(args)) {
             arg.type.verifyAssignableTo(expected)
         }
-        resultType.verifyAssignableTo(fnType.to)
+        resultType.verifyAssignableTo(calleeType.to)
 
     }
     return emit(HIRStatement.Call(location, resultType, name, callee, args))

--- a/hadesboot/src/main/kotlin/hadesc/hir/HIRDefinition.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/HIRDefinition.kt
@@ -31,7 +31,7 @@ sealed class HIRDefinition: HasLocation {
         val name get() = signature.name
         val typeParams get() = signature.typeParams
         val type get(): Type {
-            val functionType = Type.Function(
+            val functionPtrType = Type.FunctionPtr(
                     from = params.map { it.type },
                     to = returnType,
                     traitRequirements = null
@@ -39,15 +39,15 @@ sealed class HIRDefinition: HasLocation {
             return if (typeParams != null) {
                 Type.TypeFunction(
                         params = typeParams?.map { Type.Param(Binder(Identifier(it.location, it.name))) } ?: emptyList(),
-                        body = functionType
+                        body = functionPtrType
                 )
             } else {
-                functionType
+                functionPtrType
             }
         }
 
         val fnPtrType get(): Type {
-            val functionType = Type.Function(
+            val functionPtrType = Type.FunctionPtr(
                 from = params.map { it.type },
                 to = returnType,
                 traitRequirements = null
@@ -55,10 +55,10 @@ sealed class HIRDefinition: HasLocation {
             return if (typeParams != null) {
                 Type.TypeFunction(
                     params = typeParams?.map { Type.Param(Binder(Identifier(it.location, it.name))) } ?: emptyList(),
-                    body = functionType
+                    body = functionPtrType
                 )
             } else {
-                functionType
+                functionPtrType
             }
         }
     }
@@ -78,7 +78,7 @@ sealed class HIRDefinition: HasLocation {
             val returnType: Type,
             val externName: Name
     ) : HIRDefinition() {
-        val type get() = Type.Function(
+        val type get() = Type.FunctionPtr(
                 from = params,
                 to = returnType,
                 traitRequirements = null
@@ -120,28 +120,20 @@ sealed class HIRDefinition: HasLocation {
                     instanceConstructorType
                 else
                     Type.Application(instanceConstructorType, typeParams.map { Type.ParamRef(it.toBinder()) })
-            val fnType = Type.Function(
+            val fnType = Type.FunctionPtr(
                 from = fields.map { it.second },
                 to = instanceType,
                 traitRequirements = null
             )
 
-            val fnPtrType = Type.Ptr(fnType, isMutable = false)
-
             return if (typeParams == null)
-                fnPtrType
+                fnType
             else
                 Type.TypeFunction(
                     params = typeParams.map { Type.Param(it.toBinder()) },
-                    body = fnPtrType
+                    body = fnType
                 )
         }
-
-        fun constructorRef(location: SourceLocation) = HIRExpression.GlobalRef(
-            location,
-            constructorType,
-            name
-        )
 
         fun instanceType(typeArgs: List<Type> = emptyList()): Type {
             return if (typeParams == null) {

--- a/hadesboot/src/main/kotlin/hadesc/hir/HIRFunctionSignature.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/HIRFunctionSignature.kt
@@ -12,12 +12,11 @@ data class HIRFunctionSignature(
         val returnType: Type
 ) {
     val type get(): Type {
-        val fnType = Type.Function(params.map { it.type }, to = returnType, traitRequirements = null)
-        val ptrType = Type.Ptr(fnType, isMutable = false)
+        val fnType = Type.FunctionPtr(params.map { it.type }, to = returnType, traitRequirements = null)
         return if (typeParams == null)
-            ptrType
+            fnType
         else
-            Type.TypeFunction(typeParams.map { Type.Param(it.toBinder()) }, ptrType)
+            Type.TypeFunction(typeParams.map { Type.Param(it.toBinder()) }, fnType)
     }
     fun prettyPrint(): String {
         val typeParamsStr = if (typeParams == null)

--- a/hadesboot/src/main/kotlin/hadesc/hir/HIRStatement.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/HIRStatement.kt
@@ -178,7 +178,7 @@ sealed interface HIRStatement: HIRNode {
     data class AllocateClosure(
         override val location: SourceLocation,
         override val name: Name,
-        val type: Type.Function,
+        val type: Type.Closure,
         val function: HIROperand,
         val ctxPtr: HIROperand
     ): HIRStatement, NameBinder, StraightLineInstruction {

--- a/hadesboot/src/main/kotlin/hadesc/hir/passes/DesugarClosures.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/passes/DesugarClosures.kt
@@ -43,7 +43,6 @@ class DesugarClosures(override val namingCtx: NamingContext): AbstractHIRTransfo
         check(ctxPtr.type == Type.Void.ptr())
 
         emitCall(
-            statement.type,
             fnPtr,
             statement.args.map { transformExpression(it) } + ctxPtr,
             name = statement.name

--- a/hadesboot/src/main/kotlin/hadesc/hir/passes/HIRTransformer.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/passes/HIRTransformer.kt
@@ -221,7 +221,7 @@ interface HIRTransformer: TypeTransformer, HIRBuilder {
             HIRStatement.AllocateClosure(
                 statement.location,
                 statement.name,
-                lowerType(statement.type) as Type.Function,
+                lowerType(statement.type) as Type.Closure,
                 statement.function,
                 transformOperand(statement.ctxPtr),
             )

--- a/hadesboot/src/main/kotlin/hadesc/hir/passes/Monomorphization.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/passes/Monomorphization.kt
@@ -268,7 +268,7 @@ class Monomorphization(
         val implMethodNames = impl.methods
         return HIRExpression.GlobalRef(
             expression.location,
-            Type.Ptr(Type.Void, isMutable = false),
+            lowerType(expression.type),
             checkNotNull(implMethodNames[expression.methodName])
         )
     }
@@ -338,6 +338,7 @@ class Monomorphization(
         val (candidate, subst) = eligibleCandidates.first()
         val result = MonoImpl(
             generateImplMethodMap(candidate, subst),
+
             generateImplAssociatedTypeMap(candidate, subst)
         )
         monoImplCache[implName] = result

--- a/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGen.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGen.kt
@@ -664,10 +664,13 @@ class HIRGen(private val ctx: Context): ASTContext by ctx, HIRGenModuleContext, 
         return if (enumConstructorBinding != null && expression !is Expression.TypeApplication) {
             if (enumConstructorBinding.case.params == null) {
                 emitCall(
-                    withAppliedTypes.type,
-                    withAppliedTypes,
+                    withAppliedTypes.withType(
+                        Type.FunctionPtr(
+                            from = listOf(),
+                            to = withAppliedTypes.type,
+                        )
+                    ),
                     emptyList(),
-                    skipVerification = true // FIXME
                 ).result()
             } else {
                 withAppliedTypes

--- a/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGenClosure.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGenClosure.kt
@@ -54,7 +54,7 @@ internal class HIRGenClosure(
         val closureRef = emit(HIRStatement.AllocateClosure(
             currentLocation,
             ctx.makeUniqueName("closure"),
-            ctx.analyzer.reduceGenericInstances(expression.type) as Type.Function,
+            ctx.analyzer.reduceGenericInstances(expression.type) as Type.Closure,
             fnRef,
             contextRef.ptr()
         ))

--- a/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGenExpression.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGenExpression.kt
@@ -186,7 +186,6 @@ internal class HIRGenExpression(
                 expression.args.map { lowerExpression(it.expression) }
             }
         return emitCall(
-            resultType = expression.type,
             callee = callee,
             args = args
         ).result()

--- a/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGenExpression.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGenExpression.kt
@@ -166,7 +166,7 @@ internal class HIRGenExpression(
             return lowerIntrinsicCall(expression)
         }
         val callee = lowerExpression(expression.callee)
-        if (callee.type is Type.Function) {
+        if (callee.type is Type.Closure) {
             return emit(HIRStatement.InvokeClosure(
                 location = expression.location,
                 name = namingCtx.makeUniqueName(),
@@ -176,7 +176,7 @@ internal class HIRGenExpression(
             )).result()
         } else {
             val calleeType = callee.type
-            check(calleeType is Type.Ptr && calleeType.to is Type.Function)
+            check(calleeType is Type.FunctionPtr)
         }
         val receiver = ctx.analyzer.getCallReceiver(expression)?.let { lowerExpression(it) }
         val args =

--- a/hadesboot/src/main/kotlin/hadesc/parser/Parser.kt
+++ b/hadesboot/src/main/kotlin/hadesc/parser/Parser.kt
@@ -1293,6 +1293,21 @@ class Parser(
                     )
                 }
             }
+            tt.DEF -> {
+                val start = advance()
+                expect(tt.LPAREN)
+                val from = parseSeperatedList(tt.COMMA, terminator = tt.RPAREN) {
+                    parseTypeAnnotation()
+                }
+                expect(tt.RPAREN)
+                expect(tt.ARROW)
+                val returnType = parseTypeAnnotation()
+                return TypeAnnotation.FunctionPtr(
+                    from = from,
+                    to = returnType,
+                    location = SourceLocation.between(start, returnType)
+                )
+            }
             tt.VBAR -> {
                 val start = advance()
                 val from = parseSeperatedList(tt.COMMA, terminator = tt.VBAR) {
@@ -1301,7 +1316,7 @@ class Parser(
                 expect(tt.VBAR)
                 expect(tt.ARROW)
                 val to = parseTypeAnnotation()
-                TypeAnnotation.Function(
+                TypeAnnotation.Closure(
                         makeLocation(start, to),
                         from,
                         to

--- a/hadesboot/src/main/kotlin/llvm/Builder.kt
+++ b/hadesboot/src/main/kotlin/llvm/Builder.kt
@@ -13,11 +13,8 @@ val B.ref get() = this
 fun B.positionAtEnd(block: LLVMBasicBlockRef) =
     LLVM.LLVMPositionBuilderAtEnd(this, block)
 
-fun B.buildAlloca(type: LLVMTypeRef, name: String, alignmentInBytes: Int): LLVMValueRef {
-    val instr = LLVM.LLVMBuildAlloca(this, type, name)
-    LLVM.LLVMSetAlignment(instr, alignmentInBytes)
-    return instr
-}
+fun B.buildAlloca(type: LLVMTypeRef, name: String): LLVMValueRef =
+    LLVM.LLVMBuildAlloca(this, type, name)
 
 fun B.buildLoad(ptr: LLVMValueRef, name: String): LLVMValueRef {
     return LLVM.LLVMBuildLoad(this, ptr, name)

--- a/hadesboot/src/main/kotlin/llvm/Module.kt
+++ b/hadesboot/src/main/kotlin/llvm/Module.kt
@@ -15,8 +15,6 @@ fun M.addGlobal(name: String, type: Type): Value {
 fun M.addModuleFlag(key: String, value: LLVMMetadataRef, flags: Int = LLVM.LLVMModuleFlagBehaviorError) =
     LLVM.LLVMAddModuleFlag(this, flags, key, key.length.toLong(), value)
 
-fun M.getSourceFileName(): String = LLVM.LLVMGetSourceFileName(this, SizeTPointer(0)).string
-
 val M.ref get() = this
 
 fun M.getFunction(name: String): Value? {
@@ -27,7 +25,12 @@ fun M.getNamedGlobal(name: String): Value? {
     return LLVM.LLVMGetNamedGlobal(this, name)
 }
 
-fun M.addFunction(name: String, type: Type): LLVMValueRef = LLVM.LLVMAddFunction(this, name, type)
+fun M.addFunction(name: String, from: List<Type>, to: Type): LLVMValueRef =
+    LLVM.LLVMAddFunction(
+        this,
+        name,
+        functionType(returns = to, types = from, variadic = false)
+    )
 
 fun M.prettyPrint(): String =
     LLVM.LLVMPrintModuleToString(this).string

--- a/test/closure_checking.hds
+++ b/test/closure_checking.hds
@@ -7,7 +7,7 @@ enum T {
     V(closure: || -> Void);
 }
 
-type ReturnsClosure = *|| -> || -> Void;
+type ReturnsClosure = def() -> || -> Void;
 
 def returns_closure(): || -> Void {
 }

--- a/test/enum_generic_without_args.hds
+++ b/test/enum_generic_without_args.hds
@@ -1,0 +1,7 @@
+def main(): Void {
+    val x = Option.None[usize]
+}
+
+enum Option[T] {
+    None
+}

--- a/test/function_pointer_types.hds
+++ b/test/function_pointer_types.hds
@@ -1,6 +1,6 @@
 import submodule.test_utils as utils;
 def main(): Void {
-    val fptr: *|Int| -> Bool = is_greater_than_5;
+    val fptr: def(Int) -> Bool = is_greater_than_5;
     utils.print_bool(fptr(65));
 }
 

--- a/test/function_types_and_values.hds
+++ b/test/function_types_and_values.hds
@@ -9,6 +9,6 @@ def main(): Void {
     utils.print_bool(invoke(ten, greater_than_5))
 }
 
-def invoke[T, U](value: T, fn: *|T| -> U): U {
+def invoke[T, U](value: T, fn: def(T) -> U): U {
     return fn(value);
 }


### PR DESCRIPTION
Syntactically differenciate between Closure and Function pointer types. This fixes some internal transformation bugs that we weren't able to lower properly because we didn't know if it was a closure or a plain old function pointer.

In particular, a pointer to a closure can be passed to a load instruction, whereas it doesn't make sense to load from a function pointer

```scala
// function pointer that takes 2 params, X, Y and returns an X
type CFunctionPtr = def(X, Y) -> X 

// closure
type ClosureVal = |X, Y| -> X
```