### PR TITLE
Feature/diagnostics json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test_build
 .DS_Store
 /stdlib/libhdc.o
 /libhdc.o
+/.hades

--- a/hadesboot/build.gradle.kts
+++ b/hadesboot/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 val logbackVersion = "1.4.5"
 val slf4jVersion = "2.0.6"
 val junitVersion = "5.9.2"
+val kotlinxSerializationVersion = "1.4.1"
 
 application {
     group = "org.hades"
@@ -34,6 +35,8 @@ dependencies {
     implementation("com.charleskorn.kaml:kaml:0.51.0")
 
     testImplementation(kotlin("test"))
+
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")

--- a/hadesboot/src/main/kotlin/hadesc/BuildOptions.kt
+++ b/hadesboot/src/main/kotlin/hadesc/BuildOptions.kt
@@ -23,6 +23,7 @@ data class YamlBuildOptions(
     val cFlags: List<String> = emptyList(),
     val libs: List<String> = emptyList(),
     val directories: List<String> = emptyList(),
+    val jsonDiagnostics: Boolean = false
 )
 
 data class BuildOptions(
@@ -36,6 +37,7 @@ data class BuildOptions(
     val enableHIRVerifier: Boolean,
     val dumpHIRGen: Boolean,
     val enableLLVMVerifier: Boolean,
+    val jsonDiagnostics: Boolean,
 ) : Options
 
 class BuildCLIOptions: OptionGroup() {
@@ -56,6 +58,9 @@ class BuildCLIOptions: OptionGroup() {
     private val libs by option("-l").multiple()
     private val enableHIRVerifier by option("--enable-hir-verifier").flag(default = false)
     private val enableLLVMVerifier by option("--enable-llvm-verifier").flag(default = false)
+    private val jsonDiagnostics by option("--json-diagnostics")
+        .flag(default = false)
+        .help("Emit errors and warnings to .hades/diagnostics.json")
 
     private val fromProjectYML = if (File("hades.yml").exists()) {
         val text = File("hades.yml").readText()
@@ -88,6 +93,7 @@ class BuildCLIOptions: OptionGroup() {
             enableHIRVerifier = enableHIRVerifier,
             dumpHIRGen = dumpHIRGen,
             enableLLVMVerifier = enableLLVMVerifier,
+            jsonDiagnostics = jsonDiagnostics,
         )
     }
 }

--- a/hadesboot/src/main/kotlin/hadesc/location/Position.kt
+++ b/hadesboot/src/main/kotlin/hadesc/location/Position.kt
@@ -1,5 +1,8 @@
 package hadesc.location
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Position(
     val line: Int,
     val column: Int,

--- a/hadesboot/src/main/kotlin/hadesc/location/SourceLocation.kt
+++ b/hadesboot/src/main/kotlin/hadesc/location/SourceLocation.kt
@@ -1,5 +1,8 @@
 package hadesc.location
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class SourceLocation(
     val file: SourcePath,
     val start: Position,

--- a/hadesboot/src/main/kotlin/hadesc/location/SourcePath.kt
+++ b/hadesboot/src/main/kotlin/hadesc/location/SourcePath.kt
@@ -1,7 +1,10 @@
 package hadesc.location
 
+import kotlinx.serialization.Serializable
 import java.nio.file.Path
 
+
+@Serializable
 data class SourcePath(
     val path: Path
 ) {

--- a/hadesboot/src/main/kotlin/hadesc/location/SourcePath.kt
+++ b/hadesboot/src/main/kotlin/hadesc/location/SourcePath.kt
@@ -1,14 +1,31 @@
 package hadesc.location
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.net.URI
 import java.nio.file.Path
 
 
-@Serializable
+@Serializable(with = SourcePathToURISerializer::class)
 data class SourcePath(
     val path: Path
 ) {
     override fun toString(): String {
         return path.toString()
     }
+}
+
+private class SourcePathToURISerializer: KSerializer<SourcePath> {
+    override val descriptor = PrimitiveSerialDescriptor("SourcePath", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): SourcePath =
+        SourcePath(Path.of(URI.create(decoder.decodeString())))
+
+    override fun serialize(encoder: Encoder, value: SourcePath) =
+        encoder.encodeString(value.path.toUri().toString())
+
 }

--- a/hadesboot/src/test/kotlin/hadesc/HadesTestSuite.kt
+++ b/hadesboot/src/test/kotlin/hadesc/HadesTestSuite.kt
@@ -58,7 +58,8 @@ class HadesTestSuite {
                     "--module-path", Paths.get(directory.toString(), "packages").toString(),
                     "--main", file.toString(),
                     "--enable-hir-verifier",
-                    "--internal-skip-exec"
+                    "--internal-skip-exec",
+                    "--json-diagnostics",
                 ).apply {
                     add("--c-source")
                     add(utilsCLib.toString())


### PR DESCRIPTION
Add a low effort way to show diagnostics in the IDE.
Every compiler invocation with `--json-diagnostics` will emit a `.hades/diagnostics.json` file with error info.

`vscode-hades` could listen to this file and publish LSP diagnostics. This isn't as good as a real LSP server with incremental parsing, etc, but it's the easiest to set up.