### PR TITLE
Unify Type.ParamRef and Type.Param

### DIFF
--- a/hadesboot/src/main/kotlin/hadesc/BinderId.kt
+++ b/hadesboot/src/main/kotlin/hadesc/BinderId.kt
@@ -1,0 +1,11 @@
+package hadesc
+
+/**
+ * Globally unique identifier for every name declaration
+ * that exists in the source code (or a synthetic id for
+ * builtin names).
+ * If 2 BinderIds are equal, that means they refer to the same
+ * thing (Type/Variable).
+ */
+@JvmInline
+value class BinderId(val value: UInt)

--- a/hadesboot/src/main/kotlin/hadesc/analysis/TypeAnalyzer.kt
+++ b/hadesboot/src/main/kotlin/hadesc/analysis/TypeAnalyzer.kt
@@ -48,9 +48,8 @@ class TypeAnalyzer {
                     }
             }
 
-            destination is Type.ParamRef && source is Type.ParamRef -> {
-                destination.name.identifier.name == source.name.identifier.name &&
-                    destination.name.location == source.name.location
+            destination is Type.Param && source is Type.Param -> {
+                destination.name.id == source.name.id
             }
             destination is Type.Ptr && source is Type.Ptr -> {
                 val ptrTypeAssignable = isTypeAssignableTo(source.to, destination.to)
@@ -101,6 +100,6 @@ class TypeAnalyzer {
     }
 
     fun makeParamSubstitution(params: List<Type.Param>): Substitution {
-        return params.associate { it.binder.location to makeGenericInstance(it.binder) }.toSubstitution()
+        return params.associate { it.binder.id to makeGenericInstance(it.binder) }.toSubstitution()
     }
 }

--- a/hadesboot/src/main/kotlin/hadesc/ast/Binder.kt
+++ b/hadesboot/src/main/kotlin/hadesc/ast/Binder.kt
@@ -1,5 +1,6 @@
 package hadesc.ast
 
+import hadesc.BinderId
 import hadesc.location.HasLocation
 import hadesc.location.SourceLocation
 
@@ -10,7 +11,8 @@ import hadesc.location.SourceLocation
  * variables that refer to these bindings.
  */
 data class Binder(
-    val identifier: Identifier
+    val identifier: Identifier,
+    val id: BinderId,
 ) : HasLocation {
     override val location: SourceLocation
         get() = identifier.location

--- a/hadesboot/src/main/kotlin/hadesc/ast/FunctionSignature.kt
+++ b/hadesboot/src/main/kotlin/hadesc/ast/FunctionSignature.kt
@@ -5,14 +5,15 @@ import hadesc.location.SourceLocation
 
 data class FunctionSignature(
     override val location: SourceLocation,
+    override val defId: DefId,
     val name: Binder,
-    val typeParams: List<TypeParam>?,
+    override val typeParams: List<TypeParam>?,
     val thisParamBinder: Binder?,
     val thisParamFlags: ThisParamFlags?,
     val params: List<Param>,
     val returnType: TypeAnnotation,
     val whereClause: WhereClause?
-) : HasLocation {
+) : HasLocation, HasTypeParams, HasDefId {
     init {
         check(
             thisParamBinder == null && thisParamFlags == null ||

--- a/hadesboot/src/main/kotlin/hadesc/ast/HasDefId.kt
+++ b/hadesboot/src/main/kotlin/hadesc/ast/HasDefId.kt
@@ -1,0 +1,5 @@
+package hadesc.ast
+
+sealed interface HasDefId {
+    val defId: DefId
+}

--- a/hadesboot/src/main/kotlin/hadesc/ast/HasTypeParams.kt
+++ b/hadesboot/src/main/kotlin/hadesc/ast/HasTypeParams.kt
@@ -1,0 +1,5 @@
+package hadesc.ast
+
+sealed interface HasTypeParams {
+    val typeParams: List<TypeParam>?
+}

--- a/hadesboot/src/main/kotlin/hadesc/ast/Param.kt
+++ b/hadesboot/src/main/kotlin/hadesc/ast/Param.kt
@@ -35,4 +35,4 @@ data class TypeParam(
         return other is Binder && location == other.location
     }
 }
-fun Iterable<Pair<TypeParam, Type>>.toSubstitution() = Substitution(ofMap = associate { it.first.location to it.second })
+fun Iterable<Pair<TypeParam, Type>>.toSubstitution() = Substitution(ofMap = associate { it.first.binder.id to it.second })

--- a/hadesboot/src/main/kotlin/hadesc/codegen/HIRToLLVM.kt
+++ b/hadesboot/src/main/kotlin/hadesc/codegen/HIRToLLVM.kt
@@ -265,7 +265,7 @@ class HIRToLLVM(
         is Type.FunctionPtr -> LLVM.LLVMDIBuilderCreateNullPtrType(diBuilder)
         is Type.Constructor -> diBuilder.createBasicType(name.mangle(), sizeInBits)
         is Type.UntaggedUnion -> LLVM.LLVMDIBuilderCreateNullPtrType(diBuilder)
-        is Type.ParamRef,
+        is Type.Param,
         is Type.TypeFunction,
         is Type.GenericInstance,
         is Type.Application,
@@ -879,7 +879,7 @@ class HIRToLLVM(
                 checkNotNull(structTypes[type.name])
             }
         }
-        is Type.ParamRef -> requireUnreachable()
+        is Type.Param -> requireUnreachable()
         is Type.GenericInstance -> requireUnreachable()
         is Type.Application -> requireUnreachable()
         is Type.Size -> sizeTy

--- a/hadesboot/src/main/kotlin/hadesc/context/Context.kt
+++ b/hadesboot/src/main/kotlin/hadesc/context/Context.kt
@@ -1,5 +1,6 @@
 package hadesc.context
 
+import hadesc.BinderId
 import hadesc.BuildOptions
 import hadesc.Name
 import hadesc.analysis.Analyzer
@@ -13,6 +14,8 @@ import hadesc.hir.analysis.UseAfterMoveAnalyzer
 import hadesc.hir.passes.*
 import hadesc.hir.verifier.HIRVerifier
 import hadesc.hirgen.HIRGen
+import hadesc.location.Position
+import hadesc.location.SourceLocation
 import hadesc.location.SourcePath
 import hadesc.logging.logger
 import hadesc.parser.Parser
@@ -30,6 +33,9 @@ interface ASTContext {
 interface NamingContext {
     fun makeUniqueName(prefix: String = ""): Name
     fun makeName(text: String): Name = Name(text)
+
+    fun makeBinderId(): BinderId
+    val builtinSourceLocation: SourceLocation
 }
 interface GlobalConstantContext {
     val enumTagType: Type
@@ -57,6 +63,12 @@ class Context(
     override val enumTagType: Type = Type.u8
 
     val diagnosticReporter = DiagnosticReporter(fileTextProvider)
+
+    override val builtinSourceLocation: SourceLocation = SourceLocation(
+        SourcePath(Path.of("builtin")),
+        start = Position(0, 0),
+        stop = Position(0, 0),
+    )
 
     override val Expression.type get() = analyzer.typeOfExpression(this)
 
@@ -191,6 +203,9 @@ class Context(
 
     private var nextSourceFileId = 0
     fun makeSourceFileId() = SourceFileId(nextSourceFileId).also { nextSourceFileId++ }
+
+    private var nextBinderId = 0U
+    override fun makeBinderId() = BinderId(nextBinderId).also { nextBinderId++ }
 }
 
 interface FileTextProvider {

--- a/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
+++ b/hadesboot/src/main/kotlin/hadesc/frontend/Checker.kt
@@ -93,7 +93,7 @@ class Checker(val ctx: Context) {
         val foundAssociatedTypes = mutableSetOf<Name>()
         val associatedTypeSubstitution =
             implDef.body.filterIsInstance<Declaration.TypeAlias>().associate {
-                requireNotNull(expectedAssociatedTypes[it.name.name]).location to ctx.analyzer.annotationToType(it.rhs)
+                requireNotNull(expectedAssociatedTypes[it.name.name]).id to ctx.analyzer.annotationToType(it.rhs)
             }.toSubstitution()
 
         for (declaration in implDef.body) {

--- a/hadesboot/src/main/kotlin/hadesc/hir/HIRDefinition.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/HIRDefinition.kt
@@ -39,7 +39,7 @@ sealed class HIRDefinition : HasLocation {
             )
             return if (typeParams != null) {
                 Type.TypeFunction(
-                    params = typeParams?.map { Type.Param(Binder(Identifier(it.location, it.name))) } ?: emptyList(),
+                    params = typeParams?.map { Type.Param(it.toBinder()) } ?: emptyList(),
                     body = functionPtrType
                 )
             } else {
@@ -55,7 +55,7 @@ sealed class HIRDefinition : HasLocation {
             ).ptr()
             return if (typeParams != null) {
                 Type.TypeFunction(
-                    params = typeParams?.map { Type.Param(Binder(Identifier(it.location, it.name))) } ?: emptyList(),
+                    params = typeParams?.map { Type.Param(it.toBinder()) } ?: emptyList(),
                     body = functionPtrType
                 )
             } else {
@@ -120,7 +120,7 @@ sealed class HIRDefinition : HasLocation {
                 if (typeParams == null) {
                     instanceConstructorType
                 } else {
-                    Type.Application(instanceConstructorType, typeParams.map { Type.ParamRef(it.toBinder()) })
+                    Type.Application(instanceConstructorType, typeParams.map { Type.Param(it.toBinder()) })
                 }
             val fnType = Type.FunctionPtr(
                 from = fields.map { it.second },

--- a/hadesboot/src/main/kotlin/hadesc/hir/HIRTypeParam.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/HIRTypeParam.kt
@@ -1,5 +1,6 @@
 package hadesc.hir
 
+import hadesc.BinderId
 import hadesc.Name
 import hadesc.ast.Binder
 import hadesc.ast.Identifier
@@ -7,9 +8,10 @@ import hadesc.location.SourceLocation
 
 data class HIRTypeParam(
     val location: SourceLocation,
-    val name: Name
+    val name: Name,
+    val id: BinderId
 ) {
     fun prettyPrint(): String = name.text
 
-    fun toBinder(): Binder = Binder(Identifier(location, name))
+    fun toBinder(): Binder = Binder(Identifier(location, name), id)
 }

--- a/hadesboot/src/main/kotlin/hadesc/hir/TypeTransformer.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/TypeTransformer.kt
@@ -13,7 +13,7 @@ interface TypeTransformer {
         is Type.Ptr -> lowerRawPtrType(type)
         is Type.FunctionPtr -> lowerFunctionType(type)
         is Type.Constructor -> lowerTypeConstructor(type)
-        is Type.ParamRef -> lowerParamRefType(type)
+        is Type.Param -> lowerParamRefType(type)
         is Type.GenericInstance -> lowerGenericInstance(type)
         is Type.Application -> lowerTypeApplication(type)
         is Type.UntaggedUnion -> lowerUntaggedUnionType(type)
@@ -94,7 +94,7 @@ interface TypeTransformer {
 
     fun lowerTypeConstructor(type: Type.Constructor): Type = type
 
-    fun lowerParamRefType(type: Type.ParamRef): Type = type
+    fun lowerParamRefType(type: Type.Param): Type = type
 
     fun lowerTypeApplication(type: Type.Application): Type = Type.Application(
         callee = lowerType(type.callee) as Type.Constructor,
@@ -117,7 +117,7 @@ interface TypeVisitor {
         is Type.Ptr -> visitRawPtrType(type)
         is Type.FunctionPtr -> visitFunctionType(type)
         is Type.Constructor -> visitTypeConstructor(type)
-        is Type.ParamRef -> visitParamRefType(type)
+        is Type.Param -> visitParamRefType(type)
         is Type.GenericInstance -> visitGenericInstance(type)
         is Type.Application -> visitTypeApplication(type)
         is Type.UntaggedUnion -> visitUntaggedUnionType(type)
@@ -180,7 +180,7 @@ interface TypeVisitor {
 
     fun visitTypeConstructor(type: Type.Constructor) = Unit
 
-    fun visitParamRefType(type: Type.ParamRef) = Unit
+    fun visitParamRefType(type: Type.Param) = Unit
 
     fun visitTypeApplication(type: Type.Application) {
         visitType(type.callee)

--- a/hadesboot/src/main/kotlin/hadesc/hir/passes/DesugarClosures.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/passes/DesugarClosures.kt
@@ -68,13 +68,13 @@ class DesugarClosures(override val namingCtx: NamingContext) : AbstractHIRTransf
         )
         val structName = namingCtx.makeName("\$builtin.Closure")
         val typeParamName = namingCtx.makeName("T")
-        val typeParam = Binder(Identifier(location, typeParamName))
+        val typeParam = Binder(Identifier(location, typeParamName), namingCtx.makeBinderId())
         val def = HIRDefinition.Struct(
             location = location,
-            typeParams = listOf(HIRTypeParam(location, typeParamName)),
+            typeParams = listOf(HIRTypeParam(location, typeParamName, typeParam.id)),
             fields = listOf(
                 closureCtxFieldName to Type.Void.ptr(),
-                closureFunctionPtrName to fnTypeThatReturns(Type.ParamRef(typeParam)).ptr()
+                closureFunctionPtrName to fnTypeThatReturns(Type.Param(typeParam)).ptr()
             ),
             name = structName.toQualifiedName()
         )

--- a/hadesboot/src/main/kotlin/hadesc/hir/passes/HIRTransformer.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hir/passes/HIRTransformer.kt
@@ -478,7 +478,10 @@ interface HIRTransformer : TypeTransformer, HIRBuilder {
             location = expression.location,
             type = lowerType(expression.type),
             name = transformParamName(expression.name),
-            binder = Binder(Identifier(expression.binder.location, transformParamName(expression.name)))
+            binder = Binder(
+                Identifier(expression.binder.location, transformParamName(expression.name)),
+                expression.binder.id
+            )
         )
     }
 
@@ -520,7 +523,7 @@ interface HIRTransformer : TypeTransformer, HIRBuilder {
     }
 
     fun transformTypeParam(param: HIRTypeParam): HIRTypeParam {
-        return HIRTypeParam(param.location, param.name)
+        return HIRTypeParam(param.location, param.name, param.id)
     }
 
     fun transformParam(param: HIRParam): HIRParam {

--- a/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGenClosure.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGenClosure.kt
@@ -41,7 +41,7 @@ internal class HIRGenClosure(
             if (captureStruct.typeParams == null) {
                 emptyList()
             } else {
-                captureInfo.types.map { Type.ParamRef(it) }
+                captureInfo.types.map { Type.Param(it) }
             }
         val contextRef = emitAlloca("closureCtxPtr", captureStruct.instanceType(captureTypeArgs))
 
@@ -107,7 +107,7 @@ internal class HIRGenClosure(
             HIRDefinition.Struct(
                 location = location,
                 name = namingCtx.makeUniqueName("ClosureCaptures").toQualifiedName(),
-                typeParams = captureInfo.types.map { HIRTypeParam(it.location, it.name) },
+                typeParams = captureInfo.types.map { HIRTypeParam(it.location, it.name, it.id) },
                 fields = captureInfo.values.map {
                     val captureTy = it.value.second
                     val capturedBinding = it.value.first
@@ -143,12 +143,12 @@ internal class HIRGenClosure(
             if (captureStruct.typeParams == null) {
                 emptyList()
             } else {
-                captureInfo.types.map { Type.ParamRef(it) }
+                captureInfo.types.map { Type.Param(it) }
             }
 
         val captureParam = HIRParam(
             expression.location,
-            Binder(Identifier(currentLocation, closureCtxParamName)),
+            Binder(Identifier(currentLocation, closureCtxParamName), ctx.makeBinderId()),
             captureStruct.instanceType(captureTypeArgs).ptr()
         )
         val returnType = ctx.analyzer.getReturnType(expression)
@@ -177,7 +177,7 @@ internal class HIRGenClosure(
         val signature = HIRFunctionSignature(
             currentLocation,
             fnName.toQualifiedName(),
-            typeParams = captureInfo.types.map { HIRTypeParam(it.location, it.name) }.ifEmpty { null },
+            typeParams = captureInfo.types.map { HIRTypeParam(it.location, it.name, it.id) }.ifEmpty { null },
             params = expression.params.map {
                 HIRParam(it.location, it.binder, ctx.analyzer.getParamType(it))
             } + listOf(

--- a/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGenExpression.kt
+++ b/hadesboot/src/main/kotlin/hadesc/hirgen/HIRGenExpression.kt
@@ -249,7 +249,7 @@ internal class HIRGenExpression(
                 check(typeArgs.size == enumDef.typeParams.size)
                 type.applySubstitution(
                     enumDef.typeParams.zip(typeArgs).associate { (it, arg) ->
-                        it.location to arg
+                        it.binder.id to arg
                     }.toSubstitution()
                 )
             } else {

--- a/hadesboot/src/main/kotlin/hadesc/parser/Parser.kt
+++ b/hadesboot/src/main/kotlin/hadesc/parser/Parser.kt
@@ -234,6 +234,7 @@ class Parser(
         val stop = expect(tt.RBRACE)
         return Declaration.ImplementationDef(
             makeLocation(start, stop),
+            ctx.makeDefId(),
             typeParams,
             traitRef,
             traitArguments,
@@ -256,6 +257,7 @@ class Parser(
         val stop = expect(tt.RBRACE)
         return Declaration.TraitDef(
             makeLocation(start, stop),
+            ctx.makeDefId(),
             binder,
             typeParams,
             signatures
@@ -287,6 +289,7 @@ class Parser(
         val end = expect(tt.RBRACE)
         return Declaration.ExtensionDef(
             makeLocation(start, end),
+            ctx.makeDefId(),
             binder,
             typeParams,
             forType,
@@ -350,6 +353,7 @@ class Parser(
         val whereClause = parseOptionalWhereClause()
         return FunctionSignature(
             makeLocation(start, returnType),
+            ctx.makeDefId(),
             binder,
             typeParams,
             thisParam,
@@ -385,6 +389,7 @@ class Parser(
 
         return Declaration.TypeAlias(
             makeLocation(start, body),
+            ctx.makeDefId(),
             binder,
             params,
             body
@@ -1289,7 +1294,7 @@ class Parser(
     }
 
     private fun parseBinder(tokenKind: TokenKind = tt.ID): Binder {
-        return Binder(parseIdentifier(tokenKind))
+        return Binder(parseIdentifier(tokenKind), ctx.makeBinderId())
     }
 
     private fun parseOptionalAnnotation(): TypeAnnotation? = if (at(tt.COLON)) {

--- a/hadesboot/src/test/kotlin/hadesc/TraitResolverTest.kt
+++ b/hadesboot/src/test/kotlin/hadesc/TraitResolverTest.kt
@@ -27,7 +27,7 @@ class TraitResolverTest {
     fun `should resolve impls with type params`() {
         val self = param("T")
         val resolver = makeResolver(
-            impl(params(self), qn("Printable"), forType(self.ref), requires())
+            impl(params(self), qn("Printable"), forType(self), requires())
         )
 
         assert(resolver.isTraitImplemented(qn("Printable"), forType(Type.Bool)))
@@ -48,10 +48,10 @@ class TraitResolverTest {
                 params(t),
                 qn("Printable"),
                 forType(
-                    tycon("Box").ap(t.ref)
+                    tycon("Box").ap(t)
                 ),
                 requires(
-                    requirement(qn("Printable"), t.ref)
+                    requirement(qn("Printable"), t)
                 )
             )
         )
@@ -88,11 +88,11 @@ class TraitResolverTest {
             impl(
                 params(t),
                 qn("Bar"),
-                forType(t.ref),
+                forType(t),
                 requires(
                     TraitRequirement(
                         qn("Foo"),
-                        listOf(t.ref),
+                        listOf(t),
                         negated = true
                     )
                 )
@@ -132,7 +132,8 @@ class TraitResolverTest {
                         Position(line, column)
                     ),
                     Name(name)
-                )
+                ),
+                BinderId(0U)
             )
         )
     }


### PR DESCRIPTION
This simplifies the code significantly.
We Type.Param is now also comparable by its id.

Previously, we relied on the source location of
a type parameter to be the identity of the type.
This was annoying to do with compiler generated
type parameters.

This opens the door to removing the dependency
from Type to Binder. I'm trying to make sure
that the resolved types don't refer to the AST
nodes directly.